### PR TITLE
Add latest tagging

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,3 +51,20 @@ jobs:
       tags: |
         ${{ needs.setup.outputs.latest }}
 
+  summary:
+    runs-on: ubuntu-latest
+    needs: [build-image]
+    if: success() || failure()
+    steps:
+      - name: "Generate summary"
+        run: |
+          {
+            echo '# Subscription Cleanup Job'
+            # if build-image was successful
+            if [ "${{ needs.build-image.result }}" == "success" ]; then
+              printf '\n\n## Image\n'
+              printf '\n```json\n'
+              echo '${{ needs.build-image.outputs.images }}' | jq
+              printf '\n```\n'
+            fi
+          } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,10 +24,30 @@ permissions:
   contents: read # This is required for actions/checkout
 
 jobs:
+  setup:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      latest: ${{ steps.latest.outputs.latest || '' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - id: latest
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name == 'push'
+        run: echo "latest=latest" >> $GITHUB_OUTPUT
+
   build-image:
+    needs: [setup]
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: subscription-cleanup-job
       dockerfile: Dockerfile.job
       context: ./
       export-tags: false
+      tags: |
+        ${{ needs.setup.outputs.latest }}
+


### PR DESCRIPTION
This pull request introduces a new setup job and a summary job in the GitHub Actions workflow configuration file `.github/workflows/build.yaml`.

Enhancements to GitHub Actions workflow:

* Added a new `setup` job to configure permissions, check out code, and output the latest tag if the default branch is pushed. 
* Modified the `build-image` job to depend on the `setup` job and use the output from the `setup` job for tagging the Docker image. 
* Introduced a `summary` job that runs after the `build-image` job to generate a summary of the build results, including the image details if the build was successful.

---

mostly copied from [KIM](https://github.com/kyma-project/infrastructure-manager/blob/main/.github/workflows/build_kim.yaml)