### PR TITLE
Fix image name in security scanner config

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,6 +1,6 @@
 module-name: subscription-cleanup-job
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/kyma-environment-subscription-cleanup-job:latest
+  - europe-docker.pkg.dev/kyma-project/prod/subscription-cleanup-job:latest
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
This pull request includes a change to the `sec-scanners-config.yaml` file. The change updates the Docker image path for the `subscription-cleanup-job` module.

* [`sec-scanners-config.yaml`](diffhunk://#diff-d350feb504098bfc0e3ff20836550e527888d5c96bc03a6112ae5d048fd774caL3-R3): Updated the Docker image path from `kyma-environment-subscription-cleanup-job:latest` to `subscription-cleanup-job:latest`.