### PR TITLE
Bump Go version to 1.26.2

### DIFF
--- a/Dockerfile.job
+++ b/Dockerfile.job
@@ -1,5 +1,5 @@
 # Build image
-FROM --platform=$BUILDPLATFORM golang:1.25.6-alpine3.23 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine3.23 AS build
 WORKDIR /subscription-cleanup-job
 
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/subscription-cleanup-job
 
-go 1.25.5
+go 1.26.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0


### PR DESCRIPTION
## Summary
- Update Go version from 1.25.5 to 1.26.2 in go.mod
- Update Dockerfile.job to use golang:1.26.2-alpine3.23

## Changes
- go.mod: go 1.25.5 → 1.26.2
- Dockerfile.job: golang:1.25.6-alpine3.23 → golang:1.26.2-alpine3.23