### PR TITLE
fix: Update Go version to 1.26.2 for consistency and setup-envtest compatibility

### DIFF
--- a/Dockerfile.job
+++ b/Dockerfile.job
@@ -1,5 +1,5 @@
 # Build image
-FROM --platform=$BUILDPLATFORM golang:1.25.6-alpine3.23 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine3.23 AS build
 WORKDIR /subscription-cleanup-job
 
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/subscription-cleanup-job
 
-go 1.25.5
+go 1.26.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0


### PR DESCRIPTION
## Summary
This PR updates the Go version to 1.26.2 to align with other repositories in the project and ensure compatibility with the latest controller-runtime tooling.

## Changes
- Updated go.mod: Go 1.25.5 → 1.26.2
- Updated Dockerfile.job: golang:1.25.6-alpine3.23 → golang:1.26.2-alpine3.23
- Ran go mod tidy

## Why
- The latest sigs.k8s.io/controller-runtime/tools/setup-envtest requires Go >= 1.26.0
- Ensures consistency across all repositories in the project
- Prevents CI failures due to Go version mismatches

## Testing
After merge, verify that CI checks pass successfully.