### PR TITLE
Add gate job in workflows with pull_request_target

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,19 @@ permissions:
   contents: read # This is required for actions/checkout
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    environment: ${{ vars.PROTECTED_ENVIRONMENT }}
+    steps:
+      - name: Approve fork PR image build
+        run: echo "Image build approved for fork PR"
+
   setup:
+    needs: [gate]
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -32,16 +44,19 @@ jobs:
       latest: ${{ steps.latest.outputs.latest || '' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: latest
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name == 'push'
         run: echo "latest=latest" >> $GITHUB_OUTPUT
 
   build-image:
-    needs: [setup]
+    needs: [setup, gate]
+    if: >-
+      needs.setup.result == 'success' &&
+      (needs.gate.result == 'success' || needs.gate.result == 'skipped')
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: subscription-cleanup-job
@@ -54,7 +69,7 @@ jobs:
   summary:
     runs-on: ubuntu-latest
     needs: [build-image]
-    if: success() || failure()
+    if: always() && contains(needs.*.result, 'success')
     steps:
       - name: "Generate summary"
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,17 +69,14 @@ jobs:
   summary:
     runs-on: ubuntu-latest
     needs: [build-image]
-    if: always() && contains(needs.*.result, 'success')
+    if: needs.build-image.result == 'success'
     steps:
       - name: "Generate summary"
         run: |
           {
             echo '# Subscription Cleanup Job'
-            # if build-image was successful
-            if [ "${{ needs.build-image.result }}" == "success" ]; then
-              printf '\n\n## Image\n'
-              printf '\n```json\n'
-              echo '${{ needs.build-image.outputs.images }}' | jq
-              printf '\n```\n'
-            fi
+            printf '\n\n## Image\n'
+            printf '\n```json\n'
+            echo '${{ needs.build-image.outputs.images }}' | jq
+            printf '\n```\n'
           } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/run-vuln-check.yaml
+++ b/.github/workflows/run-vuln-check.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: vulncheck
         uses: golang/govulncheck-action@v1

--- a/.github/workflows/run-vuln-check.yaml
+++ b/.github/workflows/run-vuln-check.yaml
@@ -9,9 +9,6 @@ jobs:
   govuln:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
       - name: vulncheck
         uses: golang/govulncheck-action@v1
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
# Add Gate Job for Fork PR Approval in Build Workflow

### New Features

🔒 Introduced a `gate` job in the build workflow to require explicit approval before building images from fork pull requests. This improves security by ensuring that workflows triggered via `pull_request_target` from external forks must pass through a protected environment before proceeding.

### Changes

* `.github/workflows/build.yaml`:
  - Added a new `gate` job that runs only when the triggering event is `pull_request_target` from a fork repository (i.e., `head.repo.full_name != github.repository`). It uses a protected environment (`vars.PROTECTED_ENVIRONMENT`) to gate approval.
  - Updated `setup` and `build-image` jobs to depend on `gate`, allowing them to proceed only if `gate` succeeded or was skipped (i.e., for non-fork PRs).
  - Updated `build-image` conditions to explicitly check both `setup` and `gate` results.
  - Changed `summary` job condition from `success() || failure()` to `always() && contains(needs.*.result, 'success')` to ensure it runs only when at least one dependency succeeded.
  - Updated `actions/checkout` from `v4` to `v6` and changed the checkout `ref` from `head.ref` to `head.sha` for safer handling of fork PRs.

* `.github/workflows/run-vuln-check.yaml`:
  - Removed the redundant explicit `actions/checkout` step, as `govulncheck-action` handles checkout internally.

* `.github/workflows/unit-tests.yaml`:
  - Updated `actions/checkout` from `v4` to `v6`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Event Trigger: `pull_request.opened`
- Correlation ID: `40de7a0c-9ada-48c4-b610-95b0e08ddb57`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
</details>
