### PR TITLE
Update run-vuln-check.yaml to use go.mod

### DIFF
--- a/.github/workflows/run-vuln-check.yaml
+++ b/.github/workflows/run-vuln-check.yaml
@@ -15,5 +15,5 @@ jobs:
       - name: vulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.25.5
+          go-version-file: 'go.mod'
           go-package: ./...


### PR DESCRIPTION
# Update Vulnerability Check Workflow to Use `go.mod` for Go Version

### Chore

🔧 Updated the GitHub Actions security workflow to derive the Go version from `go.mod` instead of hardcoding it.

### Changes

* `.github/workflows/run-vuln-check.yaml`: Replaced the hardcoded `go-version-input: 1.25.5` with `go-version-file: 'go.mod'` in the `govulncheck-action` step. This ensures the vulnerability check always uses the same Go version as defined in the project's `go.mod` file, reducing the risk of version drift.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.49`

- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `4d86feeb-a2a8-4f6c-b499-35e9c8ae644e`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
